### PR TITLE
fix: :bug: fix `'suppressed'` event name typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function sendToDiscord(message) {
     case 'error': profile_img = config.image.error; break;
     case 'info': profile_img = config.image.info; break;
     case 'success': profile_img = config.image.success; break;
-    case 'supression': profile_img = config.image.warning; break;
+    case 'suppressed': profile_img = config.image.warning; break;
     default: profile_img = config.image.console;
   }
 


### PR DESCRIPTION
```js
sendToDiscord({
  name: 'pm2-discord-plus',
  event: 'suppressed',
  description: 'Messages are being suppressed due to rate limiting.'
});
```

The `event` name that's used to notify rate limiting/suppression is 'suppressed', which isn't currently being caught by this `switch` 🙂